### PR TITLE
Cambié ruta errónea de librería Kruskal

### DIFF
--- a/tests/test_kruskal.cpp
+++ b/tests/test_kruskal.cpp
@@ -1,7 +1,7 @@
 #include <iostream>
 #include <vector>
 #include <cassert>
-#include "C:\Users\adria\Documents\ProyectoFinalEstructurasComputacionalesAvanzadas-1\src\KruskalLib.h"
+#include "../src/KruskalLib.h"
 using namespace std;
 
 void test1() {


### PR DESCRIPTION
Había usado una ruta local, ahora está refrerenciada la ruta correcta del src.